### PR TITLE
upgrade to visual studio 2022

### DIFF
--- a/14/FileSystemExample.cpp
+++ b/14/FileSystemExample.cpp
@@ -3,7 +3,7 @@
 #include "FileSystemExample.h"
 
 using namespace std;
-namespace fs = std::experimental::filesystem::v1;
+namespace fs = std::filesystem;
 
 namespace samples
 {

--- a/PlatformSettings.props
+++ b/PlatformSettings.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?> 
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
1. Platform toolset updated to v143, which represents VS2022

2. In VS 2022, including <filesystem> provides std::filesystem, but not std::experimental::filesystem::v1, which will be deprecated in the future. Changed namespace to std::filesystem
https://docs.microsoft.com/en-us/cpp/standard-library/filesystem?view=msvc-170#syntax